### PR TITLE
fix(hook): disable color by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 - id: cmake-lint
   name: CMake Linter (ast-grep)
   entry: cmake-linter
-  args: [--report-style, short]
+  # color is disabled because it leaves behind ANSI code fragments
+  args: [--report-style, short, --color, never]
   language: node
   require_serial: true
   additional_dependencies:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,7 @@
 - id: cmake-lint
   name: CMake Linter (ast-grep)
   entry: cmake-linter
+  args: [--report-style, short]
   language: node
   require_serial: true
   additional_dependencies:

--- a/scripts/cmake-linter.sh
+++ b/scripts/cmake-linter.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 pkg_root="$NODE_PATH/cmake-linter-precommit"
+echo "$@"
 ast-grep scan -c="$pkg_root/sgconfig.yml" "$@"
 
 exit $?

--- a/scripts/cmake-linter.sh
+++ b/scripts/cmake-linter.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 pkg_root="$NODE_PATH/cmake-linter-precommit"
 ast-grep scan -c="$pkg_root/sgconfig.yml" "$@"
 

--- a/scripts/cmake-linter.sh
+++ b/scripts/cmake-linter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 pkg_root="$NODE_PATH/cmake-linter-precommit"
-ast-grep scan --report-style short --color never -c="$pkg_root/sgconfig.yml" "$@"
+ast-grep scan -c="$pkg_root/sgconfig.yml" "$@"
 
 exit $?

--- a/scripts/cmake-linter.sh
+++ b/scripts/cmake-linter.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 pkg_root="$NODE_PATH/cmake-linter-precommit"
-echo "$@"
 ast-grep scan -c="$pkg_root/sgconfig.yml" "$@"
 
 exit $?

--- a/scripts/cmake-linter.sh
+++ b/scripts/cmake-linter.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 pkg_root="$NODE_PATH/cmake-linter-precommit"
 ast-grep scan -c="$pkg_root/sgconfig.yml" "$@"
+ret=$?
 
-exit $?
+exit $ret


### PR DESCRIPTION
Using color would make the output much more readable but it also leaves behind ansi code fragments (probably due to the ansi_term crate used for color that has been unmaintained for 6 years). Color can still be activated by overriding the default args.